### PR TITLE
panicでてるのでinquiryが取得できたときだけ保存する

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1092,7 +1092,7 @@ func (h *Handler) submitHandler(userID, channelID, ts string) error {
 	// repliesの中からbotが投稿したメッセージを取得
 	var botMessage slack.Message
 	for _, reply := range replies {
-		if reply.User == h.getBotUserID() {
+		if reply.User == h.getBotUserID() || reply.BotID == h.getBotUserID() {
 			botMessage = reply
 			break
 		}
@@ -1105,9 +1105,11 @@ func (h *Handler) submitHandler(userID, channelID, ts string) error {
 	}
 
 	// ハンドラを保存
-	inquiry.Mention = userID
-	if err := h.ds.SaveInquiry(inquiry); err != nil {
-		return fmt.Errorf("UpdateInquiry failed: %w", err)
+	if inquiry != nil {
+		inquiry.Mention = userID
+		if err := h.ds.SaveInquiry(inquiry); err != nil {
+			return fmt.Errorf("UpdateInquiry failed: %w", err)
+		}
 	}
 
 	blocks := []slack.Block{


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference                                                      
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0xa9b216]                                                      
                                                                                                                             
goroutine 39 [running]:                                                                                                      
github.com/pyama86/slaffic-control/handler.(*Handler).submitHandler(0xc000228cd0, {0xc0003de470, 0xb}, {0xc0003de4e0, 0xb}, {0xc0003561c8, 0x11})                                                                                                         
        /opt/slaffic-control/handler/handler.go:1108 +0x2f6                                                                  
github.com/pyama86/slaffic-control/handler.(*Handler).handleInteractions(0xc000228cd0, 0xc00044e440)                         
        /opt/slaffic-control/handler/handler.go:129 +0xf8                                                                    
github.com/pyama86/slaffic-control/handler.(*Handler).Handle.func1()                                                         
        /opt/slaffic-control/handler/handler.go:93 +0x386                                                                    
created by github.com/pyama86/slaffic-control/handler.(*Handler).Handle in goroutine 1                                       
        /opt/slaffic-control/handler/handler.go:75 +0x1ad
```
inquiryがうまく取得できないケースがあるので、取得できたときだけ保存する。