### PR TITLE
問い合わせの統計を表示する

### DIFF
--- a/domain/infra/datastore.go
+++ b/domain/infra/datastore.go
@@ -17,6 +17,8 @@ type Datastore interface {
 	UpdateInquiryDone(string, string, bool) error
 	// 問い合わせを検索する
 	GetInquiry(string, string) (*model.Inquiry, error)
+	// 過去一ヶ月の問い合わせを取得する
+	GetMonthlyInquiries(string, time.Time) ([]model.Inquiry, error)
 
 	// メンション設定を1件取得する
 	GetMentionSetting(string) (*model.MentionSetting, error)

--- a/domain/infra/db.go
+++ b/domain/infra/db.go
@@ -3,6 +3,7 @@ package infra
 import (
 	"os"
 	"path"
+	"time"
 
 	"github.com/jinzhu/gorm"
 	_ "github.com/mattn/go-sqlite3"
@@ -67,4 +68,14 @@ func (d *DataBase) GetInquiry(botID, timestamp string) (*model.Inquiry, error) {
 		return &inquiry, nil
 	}
 	return &inquiry, err
+}
+
+func (d *DataBase) GetMonthlyInquiries(botID string, endDate time.Time) ([]model.Inquiry, error) {
+	var inquiries []model.Inquiry
+	startDate := endDate.AddDate(0, -1, 0) // 1ヶ月前
+	err := d.db.Where("bot_id = ? AND created_at BETWEEN ? AND ?",
+		botID, startDate, endDate).
+		Order("created_at desc").
+		Find(&inquiries).Error
+	return inquiries, err
 }


### PR DESCRIPTION
`@bot-name stats`で問い合わせの統計を表示できるようにする。
![CleanShot 2025-04-15 at 10 38 38@2x](https://github.com/user-attachments/assets/1333282c-d145-4fb3-a251-468803c38e8e)

200円くらいだった。