### PR TITLE
ローターション時に自由にメッセージを差し込めるようにする

### DIFF
--- a/domain/model/mention_setting.go
+++ b/domain/model/mention_setting.go
@@ -8,7 +8,7 @@ import (
 
 // メンション設定
 type MentionSetting struct {
-	BotID     string `gorm:"type:varchar(50),primary_key"`
+	BotID     string `gorm:"primary_key;type:varchar(50)"`
 	Usernames string `gorm:"type:text"` // CSV "Uxxxxx,Syyyyy"
 	CreatedAt time.Time
 }


### PR DESCRIPTION
新機能(handler.go): 環境変数からのメッセージフォーマットを使用してメンションローテーションを通知
テスト(handler_test.go): メンションローテーションのテストを追加し、環境変数に基づくメッセージ送信を検証