### PR TITLE
feat: ローテーションモード切替と担当者変更機能を追加

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,6 +20,7 @@ import (
 )
 
 var defaultChannel = os.Getenv("DEFAULT_CHANNEL")
+var rotationMode = os.Getenv("ROTATION_MODE") // weekly, daily, per_inquiry
 
 const (
 	cmdHistory = "history"
@@ -150,6 +152,12 @@ func (h *Handler) saveInquiryAndNotify(channelID, userID, priority, inputValue, 
 	); err != nil {
 		return fmt.Errorf("failed to post person in charge message: %w", err)
 	}
+
+	// per_inquiryモード: 問い合わせごとにサイレントローテーション
+	if rotationMode == "per_inquiry" {
+		h.rotateMentionsSilent()
+	}
+
 	return nil
 
 }
@@ -181,6 +189,11 @@ func (h *Handler) handleInteractions(callback *slack.InteractionCallback) {
 		case "handler_button":
 			if err := h.submitHandler(callback.User.ID, callback.Channel.ID, action.Value); err != nil {
 				slog.Error("submitHandler failed", slog.Any("err", err))
+				return
+			}
+		case "change_handler_button":
+			if err := h.openChangeHandlerModal(callback.TriggerID, callback.Channel.ID, action.Value); err != nil {
+				slog.Error("openChangeHandlerModal failed", slog.Any("err", err))
 				return
 			}
 		}
@@ -248,6 +261,10 @@ func (h *Handler) handleInteractions(callback *slack.InteractionCallback) {
 					slog.Error("Failed to post ephemeral message", slog.Any("err", err))
 					return
 				}
+			}
+		case "change_handler_modal":
+			if err := h.submitChangeHandler(callback); err != nil {
+				slog.Error("submitChangeHandler failed", slog.Any("err", err))
 			}
 		}
 	}
@@ -484,6 +501,25 @@ func (h *Handler) personInChargeMessage(inqTs string) []slack.Block {
 				inqTs,
 				slack.NewTextBlockObject("plain_text", "👋 担当者は私です！", false, false),
 			).WithStyle(slack.StylePrimary),
+			slack.NewButtonBlockElement(
+				"change_handler_button",
+				inqTs,
+				slack.NewTextBlockObject("plain_text", "🔄 担当者を変更する", false, false),
+			),
+		),
+	}
+}
+
+// 担当者変更ボタンメッセージ（担当確定後に表示）
+func changeHandlerMessage(inqTs string) []slack.Block {
+	return []slack.Block{
+		slack.NewActionBlock(
+			"change_handler_action",
+			slack.NewButtonBlockElement(
+				"change_handler_button",
+				inqTs,
+				slack.NewTextBlockObject("plain_text", "🔄 担当者を変更する", false, false),
+			),
 		),
 	}
 }
@@ -530,6 +566,52 @@ func (h *Handler) openMentionSettingModal(triggerID, channelID string) error {
 		Close:           closeText,
 		Blocks:          blocks,
 		PrivateMetadata: channelID,
+	}
+
+	_, err = h.client.OpenView(triggerID, view)
+	return err
+}
+
+type changeHandlerMeta struct {
+	ChannelID string `json:"channel_id"`
+	InquiryTS string `json:"inquiry_ts"`
+}
+
+func (h *Handler) openChangeHandlerModal(triggerID, channelID, inquiryTS string) error {
+	titleText := slack.NewTextBlockObject("plain_text", "担当者変更", false, false)
+	submitText := slack.NewTextBlockObject("plain_text", "変更", false, false)
+	closeText := slack.NewTextBlockObject("plain_text", "キャンセル", false, false)
+
+	blocks := slack.Blocks{
+		BlockSet: []slack.Block{
+			&slack.InputBlock{
+				Type:    slack.MBTInput,
+				BlockID: "change_handler_block",
+				Label:   slack.NewTextBlockObject("plain_text", "新しい担当者", false, false),
+				Element: &slack.SelectBlockElement{
+					Type:     slack.OptTypeUser,
+					ActionID: "change_handler_select",
+				},
+			},
+		},
+	}
+
+	meta, err := json.Marshal(changeHandlerMeta{
+		ChannelID: channelID,
+		InquiryTS: inquiryTS,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	view := slack.ModalViewRequest{
+		Type:            slack.ViewType("modal"),
+		CallbackID:      "change_handler_modal",
+		Title:           titleText,
+		Submit:          submitText,
+		Close:           closeText,
+		Blocks:          blocks,
+		PrivateMetadata: string(meta),
 	}
 
 	_, err = h.client.OpenView(triggerID, view)
@@ -887,7 +969,13 @@ func parseCSV(csv string) []string {
 }
 
 // startRotationMonitor: 日本時間の朝9時にローテーション
+// ROTATION_MODE=per_inquiry の場合はモニターを起動しない
 func (h *Handler) StartRotationMonitor() {
+	if rotationMode == "per_inquiry" {
+		slog.Info("Rotation mode is per_inquiry, skip rotation monitor")
+		return
+	}
+
 	dayStr := os.Getenv("ROTATION_DAY") // 0=日,1=月,...,6=土
 	if dayStr == "" {
 		dayStr = "1" // デフォルトは月曜日
@@ -920,11 +1008,17 @@ func (h *Handler) StartRotationMonitor() {
 			slog.Info("Next rotation", slog.Any("next", nextRotation), slog.Any("sleep", sleepDuration))
 			time.Sleep(sleepDuration)
 
-			// 今日が指定された曜日ならローテーションを実行
 			now = timeNow() // スリープ後に再取得
-			if int(now.Weekday()) == desiredDay {
-				slog.Info("Rotation time has come, start rotation")
+
+			if rotationMode == "daily" {
+				slog.Info("Daily rotation time has come, start rotation")
 				h.rotateMentions()
+			} else {
+				// weekly（デフォルト）: 指定された曜日のみ
+				if int(now.Weekday()) == desiredDay {
+					slog.Info("Rotation time has come, start rotation")
+					h.rotateMentions()
+				}
 			}
 		}
 	}()
@@ -1045,6 +1139,32 @@ func (h *Handler) rotateMentions() {
 
 	slog.Info("Rotation completed", slog.Any("new", first), slog.Any("all", allMentions))
 
+}
+
+// rotateMentionsSilent: Slack通知なしでローテーションのみ実行（per_inquiryモード用）
+func (h *Handler) rotateMentionsSilent() {
+	setting, err := h.ds.GetMentionSetting(h.getBotUserID())
+	if err != nil {
+		slog.Error("Failed to get latest mention setting", slog.Any("err", err))
+		return
+	}
+
+	if setting.BotID == "" || setting.Usernames == "" {
+		return
+	}
+
+	ids := parseCSV(setting.Usernames)
+	if len(ids) < 2 {
+		return
+	}
+
+	first := ids[0]
+	rotated := append(ids[1:], first)
+	newCSV := strings.Join(rotated, ",")
+	setting.Usernames = newCSV
+	if err := h.ds.UpdateMentionSetting(h.getBotUserID(), setting); err != nil {
+		slog.Error("Failed to save new mention setting (silent rotation)", slog.Any("err", err))
+	}
 }
 
 // lookupRealNameOrHandle: "Uxxxx" or "Sxxxx" をユーザー/グループ名に変換
@@ -1305,6 +1425,74 @@ func (h *Handler) submitHandler(userID, channelID, ts string) error {
 		slack.MsgOptionBlocks(blocks...),
 	); err != nil {
 		return fmt.Errorf("PostMessage failed: %w", err)
+	}
+
+	// 担当者変更ボタンを投稿
+	if _, _, err := h.client.PostMessage(
+		channelID,
+		slack.MsgOptionTS(ts),
+		slack.MsgOptionBlocks(changeHandlerMessage(ts)...),
+	); err != nil {
+		return fmt.Errorf("failed to post change handler message: %w", err)
+	}
+
+	return nil
+}
+
+func (h *Handler) submitChangeHandler(callback *slack.InteractionCallback) error {
+	var meta changeHandlerMeta
+	if err := json.Unmarshal([]byte(callback.View.PrivateMetadata), &meta); err != nil {
+		return fmt.Errorf("failed to unmarshal metadata: %w", err)
+	}
+
+	newUserID := callback.View.State.Values["change_handler_block"]["change_handler_select"].SelectedUser
+
+	inquiry, err := h.ds.GetInquiry(h.getBotUserID(), meta.InquiryTS)
+	if err != nil {
+		return fmt.Errorf("GetInquiry failed: %w", err)
+	}
+
+	if inquiry != nil && inquiry.BotID != "" {
+		inquiry.Mention = newUserID
+		inquiry.AssingneeID = newUserID
+		if err := h.ds.SaveInquiry(inquiry); err != nil {
+			return fmt.Errorf("UpdateInquiry failed: %w", err)
+		}
+	}
+
+	// 変更通知を投稿
+	blocks := []slack.Block{
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject(
+				"mrkdwn",
+				fmt.Sprintf(
+					":arrows_counterclockwise: <@%s> さんが担当者を <@%s> さんに変更しました。",
+					callback.User.ID,
+					newUserID,
+				),
+				false,
+				false,
+			),
+			nil,
+			nil,
+		),
+	}
+
+	if _, _, err := h.client.PostMessage(
+		meta.ChannelID,
+		slack.MsgOptionTS(meta.InquiryTS),
+		slack.MsgOptionBlocks(blocks...),
+	); err != nil {
+		return fmt.Errorf("PostMessage failed: %w", err)
+	}
+
+	// 再度変更ボタンを投稿
+	if _, _, err := h.client.PostMessage(
+		meta.ChannelID,
+		slack.MsgOptionTS(meta.InquiryTS),
+		slack.MsgOptionBlocks(changeHandlerMessage(meta.InquiryTS)...),
+	); err != nil {
+		return fmt.Errorf("failed to post change handler message: %w", err)
 	}
 
 	return nil

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -957,3 +957,202 @@ func TestHandler_rotateMentions_WithoutMessage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "S001,U002,U001", setting.Usernames, "Usernames should be rotated")
 }
+
+func TestHandler_rotateMentionsSilent(t *testing.T) {
+	botID := randomString(10)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := infra.NewMockSlackAPI(ctrl)
+	mockClient.EXPECT().AuthTest().Return(&slack.AuthTestResponse{UserID: botID}, nil).AnyTimes()
+
+	h, err := NewHandler()
+	assert.NoError(t, err)
+	h.client = mockClient
+	h.botID = botID
+
+	testUsernames := "U001,U002,U003"
+	err = h.ds.UpdateMentionSetting(botID, &model.MentionSetting{
+		BotID:     botID,
+		Usernames: testUsernames,
+	})
+	assert.NoError(t, err)
+
+	// サイレントローテーション実行
+	h.rotateMentionsSilent()
+
+	setting, err := h.ds.GetMentionSetting(botID)
+	assert.NoError(t, err)
+	assert.Equal(t, "U002,U003,U001", setting.Usernames, "サイレントローテーションで先頭が末尾に移動するはず")
+
+	// もう一回
+	h.rotateMentionsSilent()
+	setting, err = h.ds.GetMentionSetting(botID)
+	assert.NoError(t, err)
+	assert.Equal(t, "U003,U001,U002", setting.Usernames)
+}
+
+func TestHandler_rotateMentionsSilent_SingleUser(t *testing.T) {
+	botID := randomString(10)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := infra.NewMockSlackAPI(ctrl)
+	mockClient.EXPECT().AuthTest().Return(&slack.AuthTestResponse{UserID: botID}, nil).AnyTimes()
+
+	h, err := NewHandler()
+	assert.NoError(t, err)
+	h.client = mockClient
+	h.botID = botID
+
+	// ユーザーが1人しかいない場合はローテーションしない
+	err = h.ds.UpdateMentionSetting(botID, &model.MentionSetting{
+		BotID:     botID,
+		Usernames: "U001",
+	})
+	assert.NoError(t, err)
+
+	h.rotateMentionsSilent()
+
+	setting, err := h.ds.GetMentionSetting(botID)
+	assert.NoError(t, err)
+	assert.Equal(t, "U001", setting.Usernames, "1人の場合はローテーションしない")
+}
+
+func TestHandler_perInquiryRotation(t *testing.T) {
+	origMode := rotationMode
+	rotationMode = "per_inquiry"
+	defer func() { rotationMode = origMode }()
+
+	var postMessagePayloads []map[string]interface{}
+	botID := randomString(10)
+
+	server := slacktest.NewTestServer(func(c slacktest.Customize) {
+		c.Handle("/auth.test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"ok": true, "user_id": "%s", "team_id": "T1234"}`, botID)
+		}))
+		c.Handle("/chat.postMessage", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			data := map[string]interface{}{
+				"channel": r.FormValue("channel"),
+				"text":    r.FormValue("text"),
+				"blocks":  r.FormValue("blocks"),
+			}
+			postMessagePayloads = append(postMessagePayloads, data)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok": true, "ts": "1234567890.123456"}`))
+		}))
+	})
+
+	go server.Start()
+	defer server.Stop()
+
+	api := slack.New("dummy-token", slack.OptionAPIURL(server.GetAPIURL()))
+	h, err := NewHandler()
+	assert.NoError(t, err)
+	h.client = api
+	h.botID = botID
+
+	// メンション設定をセットアップ
+	err = h.ds.UpdateMentionSetting(botID, &model.MentionSetting{
+		BotID:     botID,
+		Usernames: "U001,U002,U003",
+	})
+	assert.NoError(t, err)
+
+	// 問い合わせを作成
+	h.handleMention(&myEvent{
+		User:    "U111",
+		Channel: "C999",
+		Text:    fmt.Sprintf("<@%s> テスト問い合わせ", botID),
+	})
+
+	// per_inquiryモードでローテーションが実行されたか確認
+	setting, err := h.ds.GetMentionSetting(botID)
+	assert.NoError(t, err)
+	assert.Equal(t, "U002,U003,U001", setting.Usernames, "per_inquiryモードで問い合わせ後にローテーションされるはず")
+
+	// 最初の問い合わせはU001に割り当てられているはず
+	inquiries, err := h.ds.GetLatestInquiries(botID)
+	assert.NoError(t, err)
+	assert.Len(t, inquiries, 1)
+	assert.Equal(t, "U001", inquiries[0].AssingneeID)
+}
+
+func TestHandler_submitChangeHandler(t *testing.T) {
+	var postMessagePayloads []map[string]interface{}
+	botID := randomString(10)
+
+	server := slacktest.NewTestServer(func(c slacktest.Customize) {
+		c.Handle("/auth.test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"ok": true, "user_id": "%s", "team_id": "T1234"}`, botID)
+		}))
+		c.Handle("/chat.postMessage", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			data := map[string]interface{}{
+				"channel": r.FormValue("channel"),
+				"text":    r.FormValue("text"),
+				"blocks":  r.FormValue("blocks"),
+			}
+			postMessagePayloads = append(postMessagePayloads, data)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok": true, "ts": "1234567890.123456"}`))
+		}))
+	})
+
+	go server.Start()
+	defer server.Stop()
+
+	api := slack.New("dummy-token", slack.OptionAPIURL(server.GetAPIURL()))
+	h, err := NewHandler()
+	assert.NoError(t, err)
+	h.client = api
+	h.botID = botID
+
+	// 問い合わせを作成
+	inqTS := "9999999999.000000"
+	err = h.ds.SaveInquiry(&model.Inquiry{
+		BotID:       botID,
+		Message:     "test inquiry",
+		Timestamp:   inqTS,
+		ChannelID:   "C999",
+		UserID:      "U111",
+		AssingneeID: "U001",
+		CreatedAt:   time.Now(),
+	})
+	assert.NoError(t, err)
+
+	// 担当者変更
+	meta := fmt.Sprintf(`{"channel_id":"C999","inquiry_ts":"%s"}`, inqTS)
+	callback := &slack.InteractionCallback{
+		Type: slack.InteractionTypeViewSubmission,
+		User: slack.User{ID: "U222"},
+		View: slack.View{
+			CallbackID:      "change_handler_modal",
+			PrivateMetadata: meta,
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{
+					"change_handler_block": {
+						"change_handler_select": slack.BlockAction{SelectedUser: "U333"},
+					},
+				},
+			},
+		},
+	}
+
+	err = h.submitChangeHandler(callback)
+	assert.NoError(t, err)
+
+	// 問い合わせの担当者が変更されたか確認
+	inquiry, err := h.ds.GetInquiry(botID, inqTS)
+	assert.NoError(t, err)
+	assert.Equal(t, "U333", inquiry.AssingneeID, "担当者がU333に変更されているはず")
+	assert.Equal(t, "U333", inquiry.Mention)
+
+	// 変更通知 + 変更ボタン = 2回のPostMessage
+	assert.Len(t, postMessagePayloads, 2)
+}


### PR DESCRIPTION
## Summary

- `ROTATION_MODE` 環境変数でローテーションタイミングを制御可能にした（`weekly`/`daily`/`per_inquiry`）
- 問い合わせの担当確定後に担当者を変更できるユーザーセレクトモーダルを追加
- 「担当者募集！」メッセージと担当確定後に「🔄 担当者を変更する」ボタンを表示

## ローテーションモード

| モード | 動作 |
|---|---|
| `weekly` (デフォルト) | `ROTATION_DAY` で指定した曜日の9時にローテーション |
| `daily` | 毎日9時にローテーション |
| `per_inquiry` | 問い合わせごとにサイレントローテーション（Slack通知なし） |

## 担当者変更機能

1. 「担当者募集！」メッセージに「担当者を変更する」ボタンを追加
2. ボタンクリックでユーザーセレクトモーダルを表示
3. 変更後、通知メッセージと再変更ボタンを投稿

## Test plan

- [x] 既存テスト全てパス
- [x] `TestHandler_rotateMentionsSilent` - サイレントローテーションの動作確認
- [x] `TestHandler_rotateMentionsSilent_SingleUser` - 1人の場合ローテーションしない
- [x] `TestHandler_perInquiryRotation` - per_inquiryモードで問い合わせ後にローテーションされる
- [x] `TestHandler_submitChangeHandler` - 担当者変更の動作確認
- [x] golangci-lint パス